### PR TITLE
Quick fix for the quick fix (from __future__ moved to top)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,3 +16,4 @@ v1.7.1 -- Fix a bug where whitespace would go missing when completing sentences
 v1.7.2 -- Fix a bug introduced with the last release
 v1.7.3 -- Improved performance on py2 and fixed db compatibility bug
 v1.7.4 -- Quickfix for rounding errors on py2
+v1.7.5 -- Quickfix for the quickfix (from __future__ has to be at the top)

--- a/pymarkovchain/MarkovChain.py
+++ b/pymarkovchain/MarkovChain.py
@@ -1,10 +1,9 @@
-
+from __future__ import division
 # use cPickle when using python2 for better performance
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-from __future__ import division
 import sys
 import random
 import os

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='PyMarkovChain',
-    version='1.7.4',
+    version='1.7.5',
     author='Max Wagner',
     author_email='max@trollbu.de',
     packages=['pymarkovchain',],


### PR DESCRIPTION
This doesn't run in Python 2.7.5 (didn't try other versions) as the `from __future__ ...` import must happen at the top.
